### PR TITLE
Add a server to interact with the platform inside a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ MIN_X=98.5	 MAX_X=101.5
 MIN_Y=-1.5	 MAX_Y=1.5
 MIN_H=0.8	 MAX_H=1.3
 ```
+
+### Using the platform server
+Start the server with: `serve-platform.py`.
+Then use `client-platform.sh` as if it was the actual `platform`
+command.
+
+For ease of use, set an alias with `alias platform=client-platform.sh`.

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # Build the platform tool using CMake. The first parameter must
 # be the out-of-source build directory.
@@ -21,7 +21,7 @@ fi
 
 cd "$SUPER_DIR"
 # create link
-if [ ! -f "$TARGET" ]; then
+if [ ! -e "$TARGET" ] && [ ! -h "$TARGET" ]; then
 	ln -s "$BUILD_SUBDIR/$TARGET" "$TARGET"
 fi
 

--- a/client-platform.sh
+++ b/client-platform.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+HOST="127.0.0.1"
+PORT=12345
+
+ARGS="$@"
+REPS=`echo -n "${ARGS}" | netcat ${HOST} ${PORT}`
+
+for l in "${REPS}"; do
+	MODE=`echo "${l}" | cut -c 1`
+	LINE=`echo "${l}" | cut -c 3-`
+	if [ "${MODE}" == "1" ]; then
+		echo "${LINE}" >&1
+	else
+		echo "${LINE}" >&2
+	fi
+done

--- a/platformcmd.cc
+++ b/platformcmd.cc
@@ -183,7 +183,7 @@ std::cout <<
         fprintf (stderr, "Unknown option `-%c'.\n", optopt);
       else
         fprintf (stderr,
-                 "Unknown option character `\\x%x'.\n",
+                 "Unknown option character `\\x%02X'.\n",
                  optopt);
       return 1;
     default:
@@ -223,7 +223,8 @@ std::cout <<
   
   std::cout 
 		<< COLOR_SUCCESS
-		<< "\bOK!\n"
-		<< COLOR_RESET;
+		<< "\bOK!"
+		<< COLOR_RESET
+		<< "\n";
   return 0;
 }

--- a/serve-platform.py
+++ b/serve-platform.py
@@ -1,0 +1,31 @@
+#! /usr/bin/python3
+import socket
+import sys
+import subprocess
+import os
+
+HOST = ''
+PORT = 12345
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind((HOST, PORT))
+    s.listen(1)
+    while True:
+        conn, addr = s.accept()
+        with conn:
+            while True:
+                data = conn.recv(1024)
+                if not data: break
+                dir_path = os.path.dirname(os.path.realpath(__file__))
+                p = subprocess.Popen(['{}/platform'.format(dir_path)] + data.decode('utf-8').split(' '), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+                while p.returncode is None:
+                    try:
+                        outs, errs = p.communicate(timeout=1)
+                        if len(outs) > 0:
+                            conn.sendall('\n'.join(["1:{}".format(l) for l in outs.split('\n')]).encode('utf-8'))
+                        if len(errs) > 0:
+                            conn.sendall('\n'.join(["2:{}".format(l) for l in errs.split('\n')]).encode('utf-8'))
+                    except subprocess.TimeoutExpired:
+                        pass
+                break
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    connection = None


### PR DESCRIPTION
1. Run the server inside the Docker container using `serve-platform.py`
2. Copy `client-platform.sh` to the host computer
3. Set an alias `alias platform=client-platform.sh`
4. Use `platform` as if it was the actual command (no need to update the manual with new instructions)

The Docker container must expose the port 12345.
